### PR TITLE
Improvement to CSS + Ability to Change Monospace Font for Preview

### DIFF
--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -63,6 +63,7 @@ th,
 td {
 	border: 1px solid;
 	border-collapse: collapse;
+	padding: 7px;
 }
 
 pre>code {

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -1,5 +1,14 @@
 body {
-	font-family: "Segoe WPC", "Segoe UI", "SFUIText-Light", "HelveticaNeue-Light", sans-serif, "Droid Sans Fallback";
+	font-family: -apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		"Apple Color Emoji",
+		"Segoe UI Emoji",
+		"Segoe UI Symbol";
 	font-size: 14px;
 	padding: 0 26px;
 	line-height: 1em;
@@ -37,7 +46,9 @@ h1 {
 	border-bottom-style: solid;
 }
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
 	font-weight: normal;
 }
 
@@ -47,22 +58,24 @@ blockquote {
 	border-left: 5px solid;
 }
 
-table, th, td {
-   border: 1px solid;
-   border-collapse: collapse;
+table,
+th,
+td {
+	border: 1px solid;
+	border-collapse: collapse;
 }
 
-pre > code {
+pre>code {
 	display: inline-block;
 	width: 90%;
 	color: white;
 	margin: 0px 5px;
 	font-size: 14px;
 	font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
-	background-color:black;
+	background-color: black;
 	cursor: pointer;
 	padding: 5px 1em;
-	box-shadow: 1px 1px 1px rgba(0,0,0,.25);
+	box-shadow: 1px 1px 1px rgba(0, 0, 0, .25);
 	line-height: 1.5em;
 }
 
@@ -77,9 +90,11 @@ ul.alternate {
 ol.initial {
 	list-style: decimal;
 }
-ol.initial > ol {
+
+ol.initial>ol {
 	list-style-type: lower-alpha;
 }
-ol.initial > ol > ol {
+
+ol.initial>ol>ol {
 	list-style-type: lower-roman;
 }

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -78,6 +78,10 @@ pre>code {
 	line-height: 1.5em;
 }
 
+pre > code > p {
+	margin: 0px
+}
+
 ul {
 	list-style-type: disc;
 }

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -71,7 +71,6 @@ pre>code {
 	color: white;
 	margin: 0px 5px;
 	font-size: 14px;
-	font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
 	background-color: black;
 	cursor: pointer;
 	padding: 5px 1em;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,16 @@
 	],
 	"main": "./out/extension",
 	"contributes": {
+		"configuration": {
+			"title": "Confluence Markup",
+			"properties": {
+				"confluenceMarkup.monospaceFont": {
+					"type": "string",
+					"default": "Menlo, Monaco, Consolas, monospace",
+					"description": "This is the value passed to the font-family CSS attribute for code in the preview. Provide it with a monospace font of your choice!"
+				}
+			}
+		},
 		"languages": [
 			{
 				"id": "confluence",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "confluence-markup",
 	"displayName": "Confluence markup",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"publisher": "denco",
 	"description": "Confluence markup language support for Visual Studio Code",
 	"keywords": [

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -205,7 +205,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			tableFlag = false;
 		}
 
-		result += tag;
+		result += "<p>" + tag + "</p>";
 	}
 
 	return result;

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -196,10 +196,6 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			}
 		}
 
-		// if (tag.match(/^s*$/)) {
-		// 	tag = '<br />';
-		// }
-
 		//close table
 		if (!tag.match(/<\/tr>$/) && tableFlag) {
 			tag = '</table>' + tag;

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 const EXTENTION_ID = 'denco.confluence-markup';
 const EMOTICON_PATH = '/media/emoticons/';
 const CSS_PATH = '/media/css/';
+const MONOSPACE_FONT_FAMILY = vscode.workspace.getConfiguration("confluenceMarkup").monospaceFont;
 
 function imageUri(searchUri: vscode.Uri, imageLink: string) {
 	let imageUri
@@ -60,7 +61,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			tag = tag.replace(/\+([^\+]*)\+/g, "<u>$1</u>");
 			tag = tag.replace(/\^([^\^]*)\^/g, "<sup>$1</sup>");
 			tag = tag.replace(/~([^~]*)~/g, "<sub>$1</sub>");
-			tag = tag.replace(/\{{2}(.*)\}{2}/g, "<code>$1</code>");
+			tag = tag.replace(/\{{2}(.*)\}{2}/g, `<code style='font-family: ${MONOSPACE_FONT_FAMILY}'>$1</code>`);
 			tag = tag.replace(/\?{2}(.*)\?{2}/g, "<cite>$1</cite>");
 			tag = tag.replace(/\{color:(\w+)\}(.*)\{color\}/g, "<span style='color:$1;'>$2</span>");
 
@@ -122,14 +123,14 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		// code
 		// online code tag
 		tag = tag.replace(/\{(noformat|code)[^\}]*\}(.*)\{(noformat|code)\}/, function (m0, m1, m2) {
-			return "<pre><code>" + m2.replace(/</gi, '&lt;') + "</code></pre>";
+			return `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>${m2.replace(/</gi, '&lt;')}</code></pre>`;
 		});
 
 		let re = /\{[(code)|(noformat)].*\}/;
 		let match = tag.match(re);
 		if (match) {
 			if (codeTagFlag === 0) {
-				tag = '<pre><code>';
+				tag = `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`;
 				codeTagFlag = 1;
 			} else {
 				tag = '</pre></code>';
@@ -190,14 +191,14 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 				tag = tag.replace(/_([\w ]*)_/g, "<i>$1</i>");
 			}
 		} else {
-			if (tag !== '<pre><code>') {
+			if (tag !== `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`) {
 				tag = tag.replace(/</gi, '&lt;') + '<br />';
 			}
 		}
 
-		if (tag.match(/^s*$/)) {
-			tag = '<br />';
-		}
+		// if (tag.match(/^s*$/)) {
+		// 	tag = '<br />';
+		// }
 
 		//close table
 		if (!tag.match(/<\/tr>$/) && tableFlag) {


### PR DESCRIPTION
Hello!

I was looking for an extension just like this, but I wanted to tweak the CSS a bit. The best way that I could find to actually do that was to just contribute it myself!

This update brings a few things:

1. Each line is now wrapped in a `<p>` tag in the preview so that we get better padding. Before, you'd have to triple-return to get a legitimate line break, and that didn't really sit right with me. There were some minor caveats to this approach (had to add some formatting rules to accommodate code blocks) but I think that made the preview much more "breathable".
2. I added some padding in the tables, because that was also making me claustrophobic  :)
3. I changed the font of most text to follow GitHub's way of doing things, to ensure that the experience is more consistent across users.
4. I added a single configuration setting, `confluenceMarkup.monospaceFont`, to the extension's settings. This is what is used as the `font-family` value in all instances where code/monospaced fonts are rendered in the preview. This can now be modified to your heart's content!
5. Bumped the version to `0.2.0` because of the implementation of the font-change feature. if you'd rather this be a patch release, then I'll leave that up to you.

Please let me know if you have any questions! Apologies about creating all of this from `master` branch on my own fork; in the future, I'll do everything from a `develop` branch in my own fork or something.

Once this is accepted, I was thinking about adding some more snippets, and improving on the description of the existing snippets so that it's a bit more obvious what they do.