### PR TITLE
0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Confluence Wiki Markup
 
+## 0.1.6
+* fix using css and render of emoticons rendering `Content-Security-Policy`
+* skip render empty lines
+* extend documentation
+* merge [Improvement to CSS + Ability to Change Monospace Font for Preview](https://github.com/denco/vscode-confluence-markup/pull/14), thanks to [macintacos](https://github.com/macintacos) for contributing:
+  * Add configuration property: `confluenceMarkup.monospaceFont` for monospace font, default: `Menlo, Monaco, Consolas, monospace`
+  * wrap all tags with paragraf
+
 ## 0.1.5
 * use webview api for rendering in vscode 1.33.x
 * refactor confluence snippets

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/denco.confluence-markup.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=denco.confluence-markup)
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-short/denco.confluence-markup.svg?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=denco.confluence-markup)
 
+## Description
+Provide preview for Confluence Markup while editing them in VSCode
+
 Adds syntax highlighting, snippets and preview for Confluence® Wiki files in Visual Studio Code.
 
-Preview for Confluence Markup while editing them in VSCode
-
+## Supported file extentions
 LanguageID: `confluence`
 
 Defaulft supported file extentions:
@@ -26,8 +28,11 @@ The extension can be activated in two ways
   * Linux & Windows: `ctrl+k v`
   * MAC: `cmd+k v` or `ctrl+k v`
 
-Confluence Documentation
+## Configuration properties
+  * *confluenceMarkup.monospaceFont* = `Menlo, Monaco, Consolas, monospace`
 
+
+## Confluence documentation
 * [Wiki MarkUp](https://confluence.atlassian.com/doc/confluence-wiki-markup-251003035.html)
 * [Storage Format](https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html)
 

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -1,5 +1,14 @@
 body {
-	font-family: "Segoe WPC", "Segoe UI", "SFUIText-Light", "HelveticaNeue-Light", sans-serif, "Droid Sans Fallback";
+	font-family: -apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		"Apple Color Emoji",
+		"Segoe UI Emoji",
+		"Segoe UI Symbol";
 	font-size: 14px;
 	padding: 0 26px;
 	line-height: 1em;
@@ -37,7 +46,9 @@ h1 {
 	border-bottom-style: solid;
 }
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
 	font-weight: normal;
 }
 
@@ -47,23 +58,29 @@ blockquote {
 	border-left: 5px solid;
 }
 
-table, th, td {
-   border: 1px solid;
-   border-collapse: collapse;
+table,
+th,
+td {
+	border: 1px solid;
+	border-collapse: collapse;
+	padding: 7px;
 }
 
-pre > code {
+pre>code {
 	display: inline-block;
 	width: 90%;
 	color: white;
 	margin: 0px 5px;
 	font-size: 14px;
-	font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
-	background-color:black;
+	background-color: black;
 	cursor: pointer;
 	padding: 5px 1em;
-	box-shadow: 1px 1px 1px rgba(0,0,0,.25);
+	box-shadow: 1px 1px 1px rgba(0, 0, 0, .25);
 	line-height: 1.5em;
+}
+
+pre > code > p {
+	margin: 0px
 }
 
 ul {
@@ -77,9 +94,11 @@ ul.alternate {
 ol.initial {
 	list-style: decimal;
 }
-ol.initial > ol {
+
+ol.initial>ol {
 	list-style-type: lower-alpha;
 }
-ol.initial > ol > ol {
+
+ol.initial>ol>ol {
 	list-style-type: lower-roman;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "confluence-markup",
 	"displayName": "Confluence markup",
-	"version": "0.2.0",
+	"version": "0.1.6",
 	"publisher": "denco",
 	"description": "Confluence markup language support for Visual Studio Code",
 	"keywords": [
@@ -136,7 +136,7 @@
 		"eslint": "^5.16.0",
 		"tslint": "^5.16.0",
 		"typescript": "^3.3.0",
-		"vsce": "^1.60.0",
+		"vsce": "^1.66.0",
 		"vscode": "^1.1.23"
 	},
 	"__metadata": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "confluence-markup",
 	"displayName": "Confluence markup",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"publisher": "denco",
 	"description": "Confluence markup language support for Visual Studio Code",
 	"keywords": [
@@ -39,6 +39,16 @@
 	],
 	"main": "./out/extension",
 	"contributes": {
+		"configuration": {
+			"title": "Confluence Markup",
+			"properties": {
+				"confluenceMarkup.monospaceFont": {
+					"type": "string",
+					"default": "Menlo, Monaco, Consolas, monospace",
+					"description": "This is the value passed to the font-family CSS attribute for code in the preview. Provide it with a monospace font of your choice!"
+				}
+			}
+		},
 		"languages": [
 			{
 				"id": "confluence",

--- a/src/ConfluenceContentProvider.ts
+++ b/src/ConfluenceContentProvider.ts
@@ -44,10 +44,14 @@ export class ConfluenceContentProvider implements vscode.TextDocumentContentProv
 		let body = await parseMarkup(unpackConfluenceUri(uri), document.getText());
 		let cssLink = cssUri("confluence.css");
 
+
+		// Security
+		// https://code.visualstudio.com/api/extension-guides/webview#security
 		return `<!DOCTYPE html>
 			<html>
 			<head>
 				<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https:; script-src vscode-resource:; style-src vscode-resource:;"/>
 				<link rel="stylesheet" href="${cssLink}">
 			</head>
 			<body>

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -40,7 +40,7 @@ export function cssUri(cssFile: string) {
 }
 
 export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
-	//TODO: use Tokenazer instead of line loop
+	//TODO: use Tokenizer instead of line loop
 
 	var result = '';
 	let listTag = '';
@@ -53,6 +53,10 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 	for (let entry of sourceText.split(/\r?\n/gi)) {
 		let tag = entry;
 		let html_tag = false;
+
+		if (tag.length === 0 ) {
+			continue;
+		}
 
 		if (codeTagFlag == 0) {
 			tag = tag.replace(/h(\d+)\.\s([^\n]+)/g, "<h$1>$2</h$1>");

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 const EXTENTION_ID = 'denco.confluence-markup';
 const EMOTICON_PATH = '/media/emoticons/';
 const CSS_PATH = '/media/css/';
+const MONOSPACE_FONT_FAMILY = vscode.workspace.getConfiguration("confluenceMarkup").monospaceFont;
 
 function imageUri(searchUri: vscode.Uri, imageLink: string) {
 	let imageUri
@@ -60,7 +61,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			tag = tag.replace(/\+([^\+]*)\+/g, "<u>$1</u>");
 			tag = tag.replace(/\^([^\^]*)\^/g, "<sup>$1</sup>");
 			tag = tag.replace(/~([^~]*)~/g, "<sub>$1</sub>");
-			tag = tag.replace(/\{{2}(.*)\}{2}/g, "<code>$1</code>");
+			tag = tag.replace(/\{{2}(.*)\}{2}/g, `<code style='font-family: ${MONOSPACE_FONT_FAMILY}'>$1</code>`);
 			tag = tag.replace(/\?{2}(.*)\?{2}/g, "<cite>$1</cite>");
 			tag = tag.replace(/\{color:(\w+)\}(.*)\{color\}/g, "<span style='color:$1;'>$2</span>");
 
@@ -122,14 +123,14 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		// code
 		// online code tag
 		tag = tag.replace(/\{(noformat|code)[^\}]*\}(.*)\{(noformat|code)\}/, function (m0, m1, m2) {
-			return "<pre><code>" + m2.replace(/</gi, '&lt;') + "</code></pre>";
+			return `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>${m2.replace(/</gi, '&lt;')}</code></pre>`;
 		});
 
 		let re = /\{[(code)|(noformat)].*\}/;
 		let match = tag.match(re);
 		if (match) {
 			if (codeTagFlag === 0) {
-				tag = '<pre><code>';
+				tag = `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`;
 				codeTagFlag = 1;
 			} else {
 				tag = '</pre></code>';
@@ -190,13 +191,9 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 				tag = tag.replace(/_([\w ]*)_/g, "<i>$1</i>");
 			}
 		} else {
-			if (tag !== '<pre><code>') {
+			if (tag !== `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`) {
 				tag = tag.replace(/</gi, '&lt;') + '<br />';
 			}
-		}
-
-		if (tag.match(/^s*$/)) {
-			tag = '<br />';
 		}
 
 		//close table
@@ -205,7 +202,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			tableFlag = false;
 		}
 
-		result += tag;
+		result += "<p>" + tag + "</p>";
 	}
 
 	return result;

--- a/src/test/markupParser.test.ts
+++ b/src/test/markupParser.test.ts
@@ -22,7 +22,7 @@ suite("markupParser Tests", function () {
 
     test("Test render headers", function () {
         const testFile = vscode.Uri.file(path.join(__dirname, "../../src/test/testfiles/nix/scoped/headings.confluence"));
-        const expected = '<h1>Heading 1</h1><br /><h2>Heading 2</h2><br /><h3>Heading 3</h3><br /><h4>Heading 4</h4><br /><h5>Heading 5</h5><br /><h6>Heading 6</h6><br />'
+        const expected = '<p><h1>Heading 1</h1></p><p><h2>Heading 2</h2></p><p><h3>Heading 3</h3></p><p><h4>Heading 4</h4></p><p><h5>Heading 5</h5></p><p><h6>Heading 6</h6></p>'
         const content = fs.readFileSync(testFile.fsPath, 'utf8');
         assert.equal(parseMarkup(testFile, content), expected);
     });


### PR DESCRIPTION
* fix using css and render of emoticons rendering `Content-Security-Policy`
* skip render empty lines
* extend documentation
* merge [Improvement to CSS + Ability to Change Monospace Font for Preview](https://github.com/denco/vscode-confluence-markup/pull/14), thanks to [macintacos](https://github.com/macintacos) for contributing:
  * Add configuration property: `confluenceMarkup.monospaceFont` for monospace font, default: `Menlo, Monaco, Consolas, monospace`
  * wrap all tags with paragraf
