### PR TITLE
feature/1.0.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
       - name: Install Dependencies

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        # uses: actions/checkout@v2
         uses: actions/checkout@v3
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         # uses: actions/checkout@v2
         uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
       - name: Install Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [1.0.1]
 
-- put things here
+- modified code/noformat blocks so they can be used in lists to match confluence behaviour
+- added support for code block macro titles and themes (only standard themes are supported, and there's no syntax highlighting)
+- changed test files to accomodate above changes
+- updated github workflow actions to v3
 
 ## [1.0.0](https://github.com/denco/vscode-confluence-markup/releases/tag/1.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - modified code/noformat blocks so they can be used in lists to match confluence behaviour
 - added support for code block macro titles and themes (only standard themes are supported, and there's no syntax highlighting)
-- removed `white-space: normal` for `pre > code` CSS to match confluence behaviour and commonmark spec (white space is preserved)
+- changed `white-space: normal` to `white-space: pre-wrap` for `pre > code` CSS to match confluence behaviour and commonmark spec (white space is preserved)
 - changed test files to accomodate above changes
 - updated github workflow actions to v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Confluence Wiki Markup
 
+## [1.0.1]
+
+- put things here
+
 ## [1.0.0](https://github.com/denco/vscode-confluence-markup/releases/tag/1.0.0)
 
 - non preview release [1.0.0](https://github.com/denco/vscode-confluence-markup/issues/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - modified code/noformat blocks so they can be used in lists to match confluence behaviour
 - added support for code block macro titles and themes (only standard themes are supported, and there's no syntax highlighting)
+- removed `white-space: normal` for `pre > code` CSS to match confluence behaviour and commonmark spec (white space is preserved)
 - changed test files to accomodate above changes
 - updated github workflow actions to v3
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Originally syntax from the [Confluence® Textmate Bundle](https://github.com/alk
 - Run `npm i` to install dependencies.
 - Run `npm run watch` to start compilation in watch mode.
 - Open the repository folder in VS Code and press `F5` to compile and run in a new Extension Development Host Window.
+- Local Install
+	- Run `vcse package` to create a .vsix file
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -49,15 +49,6 @@ The extension can be activated in two ways
 
 Originally syntax from the [Confluence® Textmate Bundle](https://github.com/alkemist/Confluence.tmbundle).
 
-## Development
-- Fork and clone the repository.
-- cd into the repository folder.
-- Run `npm i` to install dependencies.
-- Run `npm run watch` to start compilation in watch mode.
-- Open the repository folder in VS Code and press `F5` to compile and run in a new Extension Development Host Window.
-- Local Install
-	- Run `vcse package` to create a .vsix file
-
 ----
 
 > Confluence® and Jira® is registered trademark owned by [Atlassian](https://www.atlassian.com/)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ The extension can be activated in two ways
 
 Originally syntax from the [Confluence® Textmate Bundle](https://github.com/alkemist/Confluence.tmbundle).
 
+## Development
+- Fork and clone the repository.
+- cd into the repository folder.
+- Run `npm i` to install dependencies.
+- Run `npm run watch` to start compilation in watch mode.
+- Open the repository folder in VS Code and press `F5` to compile and run in a new Extension Development Host Window.
+
 ----
 
 > Confluence® and Jira® is registered trademark owned by [Atlassian](https://www.atlassian.com/)

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -77,11 +77,10 @@ pre > code {
 	word-break: break-space;
 	white-space: normal;
 	/* margin: 0px 5px; */
+	background:rgba(0, 0, 0, 0.15);
 	margin: 0px;
 	padding: 5px 1em;
 	line-height: 1.5em;
-	color: #d1edff;
-	background-color: #0f192a;
 }
 
 pre > code > p {

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -50,8 +50,9 @@ table, th, td {
 
 .code-panel {
 	display: block;
-    color: black;
-	background-color: red;
+	width: 90%;
+    /* color: black; */
+	/* background-color: red; */
 	border-width: 1px;
 }
 
@@ -63,6 +64,23 @@ table, th, td {
 	padding: 5px 3px;
 	margin: 0px;
 	border-bottom: none;
+}
+
+/* The two sets below provide bullets and indentation, but if another ul follows it appears as a child or inline. */
+/* this provides bullets, and indentation. */
+ul .code-panel {
+	display: list-item;
+	list-style-type: disc;
+	margin-left: 20px;
+	/* list-style-position: inside; */
+}
+
+/* this provides bullets, and indentation. But it makes it so if you want code blocks to be part ordered lists, then you're stuck with bullets.*/
+ol .code-panel {
+	display: list-item;
+	list-style-type: disc;
+	margin-left: 20px;
+	/* list-style-position: inside; */
 }
 
 pre {

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -48,44 +48,65 @@ table, th, td {
 	padding: 7px;
 }
 
-pre > code {
-	display: block;
-	background:rgba(0, 0, 0, 0.15);
-	word-wrap: break-word;
-	overflow-wrap: break-word;
-	word-break: break-space;
-	white-space: normal;
-	margin: 0px 5px;
-	padding: 5px 1em;
-	line-height: 1.5em;
-}
-
 .code-panel {
-	display: inline-block;
-	width: 90%;
+	display: block;
     color: black;
-	margin: 0px;
-	background-color: #f5f5f5;
+	background-color: red;
 	border-width: 1px;
 }
 
 .code-title {
+	display: block;
+	background:rgb(216, 207, 207);
+	color: black;
 	font-weight: bold;
 	padding: 5px 3px;
+	margin: 0px;
 	border-bottom: none;
 }
 
-.code-body {
-	padding: 3px;
-    font-family: monospace;
-    color: white;
-    background:rgba(17, 16, 16, 0.75);
+pre {
+	margin: 0px;
+}
+
+pre > code {
+	display: block;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	word-break: break-space;
 	white-space: normal;
+	/* margin: 0px 5px; */
+	margin: 0px;
+	padding: 5px 1em;
 	line-height: 1.5em;
+	background-color: rebeccapurple;
 }
+
+code {
+	display: block;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+	word-break: break-space;
+	white-space: normal;
+	/* margin: 0px 5px; */
+	margin: 0px;
+	padding: 5px 1em;
+	line-height: 1.5em;
+	background-color: rebeccapurple;
+}
+
+pre > code > p {
+	margin: 0px;
+}
+
+p:has(code) {
+	margin: 0px;
+  }
+
+/* This makes things way too tight, but it does get rid of the spacing issue with code blocks. */
+/* p:empty {
+	margin: 0px;
+} */
 
 .panel {
 	display: inline-block;
@@ -108,10 +129,6 @@ pre > code {
 	padding: 3px;
 }
 
-
-pre > code > p {
-	margin: 0px;
-}
 
 ul {
 	list-style-type: disc;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -75,7 +75,8 @@ pre > code {
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	word-break: break-space;
-	white-space: normal;
+	/* Confluence allows for indentations and whitespace preservation in code blocks */
+	/* white-space: normal; */
 	margin: 0px;
 	padding: 5px 1em;
 	line-height: 1.5em;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -60,6 +60,32 @@ pre > code {
 	line-height: 1.5em;
 }
 
+.code-panel {
+	display: inline-block;
+	width: 90%;
+    color: black;
+	margin: 0px;
+	background-color: #f5f5f5;
+	border-width: 1px;
+}
+
+.code-title {
+	font-weight: bold;
+	padding: 5px 3px;
+	border-bottom: none;
+}
+
+.code-body {
+	padding: 3px;
+    font-family: monospace;
+    color: white;
+    background:rgba(17, 16, 16, 0.75);
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+	word-break: break-space;
+	white-space: normal;
+	line-height: 1.5em;
+}
 
 .panel {
 	display: inline-block;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -51,19 +51,19 @@ table, th, td {
 .code-panel {
 	display: block;
 	width: 90%;
-    /* color: black; */
 	/* background-color: red; */
 	border-width: 1px;
 }
 
 .code-title {
 	display: block;
-	background:rgb(216, 207, 207);
+	background:#c6c3c3;
 	color: black;
 	font-weight: bold;
-	padding: 5px 3px;
-	margin: 0px;
-	border-bottom: none;
+	border-bottom-color: #ccc;
+    padding: 5px 10px;
+    overflow: hidden;
+    position: relative;
 }
 
 pre {
@@ -80,11 +80,12 @@ pre > code {
 	margin: 0px;
 	padding: 5px 1em;
 	line-height: 1.5em;
-	background-color: rebeccapurple;
+	color: #d1edff;
+	background-color: #0f192a;
 }
 
 pre > code > p {
-	margin: 0px;
+	margin: .5em 0;
 }
 
 .panel {

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -51,7 +51,6 @@ table, th, td {
 .code-block {
 	display: block;
 	width: 90%;
-	/* background-color: red; */
 	border-width: 1px;
 }
 

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -77,6 +77,7 @@ pre > code {
 	word-break: break-space;
 	/* Confluence allows for indentations and whitespace preservation in code blocks */
 	/* white-space: normal; */
+	white-space: pre-wrap;
 	margin: 0px;
 	padding: 5px 1em;
 	line-height: 1.5em;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -60,9 +60,9 @@ table, th, td {
 	color: black;
 	font-weight: bold;
 	border-bottom-color: #ccc;
-    padding: 5px 10px;
-    overflow: hidden;
-    position: relative;
+	padding: 5px 10px;
+	overflow: hidden;
+	position: relative;
 }
 
 pre {
@@ -76,7 +76,6 @@ pre > code {
 	overflow-wrap: break-word;
 	word-break: break-space;
 	white-space: normal;
-	/* margin: 0px 5px; */
 	margin: 0px;
 	padding: 5px 1em;
 	line-height: 1.5em;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -66,23 +66,6 @@ table, th, td {
 	border-bottom: none;
 }
 
-/* The two sets below provide bullets and indentation, but if another ul follows it appears as a child or inline. */
-/* this provides bullets, and indentation. */
-ul .code-panel {
-	display: list-item;
-	list-style-type: disc;
-	margin-left: 20px;
-	/* list-style-position: inside; */
-}
-
-/* this provides bullets, and indentation. But it makes it so if you want code blocks to be part ordered lists, then you're stuck with bullets.*/
-ol .code-panel {
-	display: list-item;
-	list-style-type: disc;
-	margin-left: 20px;
-	/* list-style-position: inside; */
-}
-
 pre {
 	margin: 0px;
 }
@@ -104,10 +87,6 @@ pre > code > p {
 	margin: 0px;
 }
 
-/* p:has(code) {
-	margin: 0px;
-  } */
-
 .panel {
 	display: inline-block;
 	width: 90%;
@@ -128,7 +107,6 @@ pre > code > p {
 	background-color: lightgrey;
 	padding: 3px;
 }
-
 
 ul {
 	list-style-type: disc;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -82,31 +82,13 @@ pre > code {
 	background-color: rebeccapurple;
 }
 
-code {
-	display: block;
-	word-wrap: break-word;
-	overflow-wrap: break-word;
-	word-break: break-space;
-	white-space: normal;
-	/* margin: 0px 5px; */
-	margin: 0px;
-	padding: 5px 1em;
-	line-height: 1.5em;
-	background-color: rebeccapurple;
-}
-
 pre > code > p {
 	margin: 0px;
 }
 
-p:has(code) {
+/* p:has(code) {
 	margin: 0px;
-  }
-
-/* This makes things way too tight, but it does get rid of the spacing issue with code blocks. */
-/* p:empty {
-	margin: 0px;
-} */
+  } */
 
 .panel {
 	display: inline-block;

--- a/media/css/confluence.css
+++ b/media/css/confluence.css
@@ -48,7 +48,7 @@ table, th, td {
 	padding: 7px;
 }
 
-.code-panel {
+.code-block {
 	display: block;
 	width: 90%;
 	/* background-color: red; */
@@ -72,20 +72,17 @@ pre {
 
 pre > code {
 	display: block;
+	background:rgba(0, 0, 0, 0.15);
 	word-wrap: break-word;
 	overflow-wrap: break-word;
 	word-break: break-space;
 	white-space: normal;
 	/* margin: 0px 5px; */
-	background:rgba(0, 0, 0, 0.15);
 	margin: 0px;
 	padding: 5px 1em;
 	line-height: 1.5em;
 }
 
-pre > code > p {
-	margin: .5em 0;
-}
 
 .panel {
 	display: inline-block;
@@ -106,6 +103,11 @@ pre > code > p {
 .panel-body {
 	background-color: lightgrey;
 	padding: 3px;
+}
+
+
+pre > code > p {
+	margin: .5em 0;
 }
 
 ul {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "confluence-markup",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "confluence-markup",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/glob": "^7.1.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "confluence-markup",
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "confluence-markup",
 	"displayName": "Confluence markup",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"publisher": "denco",
 	"description": "Confluence markup language support for Visual Studio Code",
 	"keywords": [

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -52,9 +52,8 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 	let result = '';
 	let listTag = '';
 	let listStyle = '';
-	let codeTagFlag = false;
+	let codeBlockTagFlag = false;
 	let innerCodeTagFlag = false;
-	let paneledCodeTagFlag = false;
 	let panelTagFlag = false;
 	let tableFlag = false;
 	let listFlag = false;
@@ -67,13 +66,13 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		if ((tag.length === 0 )
 			&& (! listFlag)
 			&& (! tableFlag)
-			&& (! codeTagFlag)
+			&& (! codeBlockTagFlag)
 			&& (! innerCodeTagFlag)
 			) {
 			continue;
 		}
 
-		if (! codeTagFlag || ! innerCodeTagFlag) {
+		if (! codeBlockTagFlag || ! innerCodeTagFlag) {
 			tag = tag.replace(/h(\d+)\.\s([^\n]+)/g, "<h$1>$2</h$1>");
 
 			// tag = tag.replace(/_([^_]*)_/g, "<em>$1</em>");
@@ -167,18 +166,18 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		});
 
 
-		// code panel tag
-		const code_re = /\{code[^}]*\}/;
+		// code block tag
+		// const code_re = /\{code[^}]*\}/;
+		const code_re = /\{code(.*)\}/;
 		const code_match = tag.match(code_re);
-		const code_panel_open_re = /\{code:(.*)\}/;
-		const code_panel_open_match = tag.match(code_panel_open_re);
-		const code_panel_close_re = /\{code\}/;
-		const code_panel_close_match = tag.match(code_panel_close_re);
+		// const code_panel_open_match = tag.match(code_panel_open_re);
+		// const code_panel_close_re = /\{code\}/;
+		// const code_panel_close_match = tag.match(code_panel_close_re);
 		if (code_match) {
-			if (code_panel_open_match && ! paneledCodeTagFlag) {
+			if (! innerCodeTagFlag  && ! codeBlockTagFlag) {
 				let codeBlockStyle = "";
 				// let titleStyle = "";
-				tag = tag.replace(code_panel_open_re, function (m0, m1) {
+				tag = tag.replace(code_re, function (m0, m1) {
 					let res = '<pre><code $codeBlockStyle>'
 					const splits = m1.split(/[|:]/);
 					splits.forEach( (el:string) => {
@@ -190,7 +189,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 						}
 						// Basic theme matching.
 						if (elems[0] === "theme"){
-							// Add some sort of switch statement in here.
+							// Predefined confluence themes.
 							switch (elems[1].toLowerCase()) {
 								case "django":
 									codeBlockStyle = `style='color:#f8f8f8;background-color:#0a2b1d;'`;
@@ -220,27 +219,22 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 					// res = res.replace('$titleStyle', titleStyle);
 					return res;
 				});
-				paneledCodeTagFlag = true;
+				codeBlockTagFlag = true;
 				// If the opening match isn't found. Check for a simple code block by looking for the closing tag without an innner code tag.
 			}
-			if (! innerCodeTagFlag && code_panel_close_match && ! paneledCodeTagFlag) {
-				tag = '<div class="code-panel"><pre><code>';
-				paneledCodeTagFlag = true;
-			}
 		}
-		// if (paneledCodeTagFlag && ! code_panel_open_match && ! code_panel_close_match) {
-		if (paneledCodeTagFlag && ! code_match) {
+		if (codeBlockTagFlag && ! code_match) {
 			// Flag the inner code, so it doesn't get modified.
 			innerCodeTagFlag = true;
 		}
-		if (code_panel_close_match && paneledCodeTagFlag && innerCodeTagFlag) {
+		if (code_match && codeBlockTagFlag && innerCodeTagFlag) {
 			tag = '</code></pre></div>';
 			//This pays attention to the list flag and adds the closing </li> tag if needed.
 			if (listFlag) {
 				tag = `${tag}</li>`;
 			}
 			innerCodeTagFlag = false;
-			paneledCodeTagFlag = false;
+			codeBlockTagFlag = false;
 		}
 
 		// original code block. keeping for reference.
@@ -257,7 +251,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		// }
 
 		const panel_re = /\{panel(.*)}/;
-		if (! paneledCodeTagFlag && tag.match(panel_re)) {
+		if (! codeBlockTagFlag && tag.match(panel_re)) {
 			if (! panelTagFlag ) {
 				let panelStyle = "";
 				let titleStyle = "";
@@ -340,7 +334,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			}
 		}
 
-		if (! codeTagFlag || ! innerCodeTagFlag) {
+		if (! innerCodeTagFlag) {
 			// lists
 			const li_re = /^([-*#]+)\s(.*)/;
 			const li_match = tag.match(li_re);
@@ -371,7 +365,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 					listArr = listArr.slice(0, li_match[1].length);
 				}
 				// This prevents the closing </li> tag from being added too prematurely.
-				if (paneledCodeTagFlag || panelTagFlag) {
+				if (codeBlockTagFlag || panelTagFlag) {
 					tag += "<li>" + li_match[2];
 				} else {
 					tag += "<li>" + li_match[2] + "</li>";

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -81,8 +81,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			tag = tag.replace(/\+([^+]*)\+/g, "<u>$1</u>");
 			tag = tag.replace(/\^([^^]*)\^/g, "<sup>$1</sup>");
 			tag = tag.replace(/~([^~]*)~/g, "<sub>$1</sub>");
-			//Modidfied to add pre tag
-			tag = tag.replace(/\\}/g, "&rbrace;").replace(/\{{2}(.*?)\}{2}/g, `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>$1</code></pre>`);
+			tag = tag.replace(/\\}/g, "&rbrace;").replace(/\{{2}(.*?)\}{2}/g, `<code style='font-family: ${MONOSPACE_FONT_FAMILY}'>$1</code>`);
 			tag = tag.replace(/\?{2}(.*)\?{2}/g, "<cite>$1</cite>");
 			tag = tag.replace(/\{color:([^}]+)\}/g, "<span style='color:$1;'>").replace(/\{color\}/g, '</span>');
 
@@ -167,104 +166,58 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			return `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>${m2.replace(/</gi, '&lt;')}</code></pre>`;
 		});
 
+
+
 		// code block tag
-		// const code_block_re = /\{code(.*)}/
-		const code_block_re = /\{code([^}]*)\}/;
-		const code_block_match = tag.match(code_block_re);
-		if (code_block_match) {
+		// const code_re = /\{code[^}]*\}/;
+		const code_re = /\{code(.*)\}/;
+		const code_match = tag.match(code_re);
+		if (code_match) {
 			if (! codeBlockTagFlag) {
 				let panelStyle = "";
 				let titleStyle = "";
-				tag = tag.replace(code_block_re, function (m0, m1, m2) {
-					let res = '<pre><code $panelStyle>'
-					const splits = m1.split(/[|:]/);
-					splits.forEach( (el:string) => {
-						const elems = el.split('=');
-						if (elems[0] === "title"){
-							res = `<div class="code-panel"><span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
-						} else {
-							res = `<div class="code-panel">${res}`;
-						}
-                        // Disabled for now.
-						// if (elems[0] === "theme"){
-						// 	if (panelStyle.length === 0) {
-						// 		panelStyle = `style='background-color: ${elems[1]};`;
-						// 	} else {
-						// 		panelStyle += ` background-color: ${elems[1]};`;
-						// 	}
-						// }
-					});
-					if (titleStyle.length > 0) {
-						titleStyle += `'`;
+				let res = '<pre><code $panelStyle>'
+				const splits = tag.split(/[|:]/);
+				splits.forEach( (el:string) => {
+					const elems = el.split('=');
+					if (elems[0] === "title"){
+						res = `<span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
 					}
-					if (panelStyle.length > 0) {
-						panelStyle += `'`;
-					}
-					res = res.replace('$panelStyle', panelStyle);
-					res = res.replace('$titleStyle', titleStyle);
-					return res;
+					// Disabled for now. I'd like to add the standard confluence code block themes later.
+					// if (elems[0] === "theme"){
+					// 	if (panelStyle.length === 0) {
+					// 		panelStyle = `style='background-color: ${elems[1]};`;
+					// 	} else {
+					// 		panelStyle += ` background-color: ${elems[1]};`;
+					// 	}
+					// }
 				});
+				res = `<div class="code-panel">${res}`;
+				if (titleStyle.length > 0) {
+					titleStyle += `'`;
+				}
+				if (panelStyle.length > 0) {
+					panelStyle += `'`;
+				}
+				res = res.replace('$panelStyle', panelStyle);
+				tag = res.replace('$titleStyle', titleStyle);
+				// console.log('tag=' + tag);
 				codeBlockTagFlag = true;
 			} else {
 				// This seems inververted. I'm not sure if it needs corrected.
 				// tag = '</pre></code>';
-				tag = '</code></pre>';
+				tag = '</code></pre></div>';
 				codeBlockTagFlag = false;
 			}
 		}
 
-		// Attempt #2
-		// const code_re = /\{code(.*)}/;
-		// const code_match = tag.match(code_re);
-		// if (code_match) {
-		// 	if (! codeTagFlag) {
-		// 		let panelStyle = "";
-		// 		let titleStyle = "";
-		// 		tag = tag.replace(code_re, function (m0, m1, m2) {
-		// 			let res = '<code class="code-body" $panelStyle>'
-		// 			const splits = m1.split(/[|:]/);
-		// 			splits.forEach( (el:string) => {
-		// 				const elems = el.split('=');
-		// 				if (elems[0] === "title"){
-		// 					// res = `<pre><div class="code-panel code-title" $titleStyle>${elems[1]}</div>${res}`;
-		// 					res = `<pre><span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
-		// 				} else {
-		// 					res = `<pre>${res}`;
-		// 				}
-        //                 // Disabled for now.
-		// 				// if (elems[0] === "theme"){
-		// 				// 	if (panelStyle.length === 0) {
-		// 				// 		panelStyle = `style='background-color: ${elems[1]};`;
-		// 				// 	} else {
-		// 				// 		panelStyle += ` background-color: ${elems[1]};`;
-		// 				// 	}
-		// 				// }
-		// 			});
-		// 			if (titleStyle.length > 0) {
-		// 				titleStyle += `'`;
-		// 			}
-		// 			if (panelStyle.length > 0) {
-		// 				panelStyle += `'`;
-		// 			}
-		// 			res = res.replace('$panelStyle', panelStyle);
-		// 			res = res.replace('$titleStyle', titleStyle);
-		// 			return res;
-		// 		});
-		// 		codeTagFlag = true;
-		// 	} else {
-		// 		tag = '</pre></code>';
-		// 		codeTagFlag = false;
-		// 	}
-		// }
-
-
 		// old code tag
 		// const code_re = /\{code[^}]*\}/;
 		// const code_match = tag.match(code_re);
-		// console.log(code_match);
 		// if (code_match) {
 		// 	if (! codeTagFlag) {
 		// 		tag = `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`;
+		// 		console.log('tag=' + tag);
 		// 		codeTagFlag = true;
 		// 	} else {
 		// 		tag = '</pre></code>';
@@ -273,7 +226,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		// }
 
 		const panel_re = /\{panel(.*)}/;
-		if (! codeTagFlag && tag.match(panel_re)) {
+		if (! codeBlockTagFlag && tag.match(panel_re)) {
 			if (! panelTagFlag ) {
 				let panelStyle = "";
 				let titleStyle = "";

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -202,6 +202,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 				tag = '</div>';
 				codeBlockTagFlag = false;
 			}
+		}
 
 
 		// old code tag

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -67,18 +67,22 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			&& (! listFlag)
 			&& (! tableFlag)
 			&& (! codeTagFlag)
+			// Added and disabled for now
+			&& (! codeBlockTagFlag)
 			) {
 			continue;
 		}
 
-		if (! codeTagFlag) {
+		if (! codeBlockTagFlag) {
 			tag = tag.replace(/h(\d+)\.\s([^\n]+)/g, "<h$1>$2</h$1>");
 
 			// tag = tag.replace(/_([^_]*)_/g, "<em>$1</em>");
+
 			tag = tag.replace(/\+([^+]*)\+/g, "<u>$1</u>");
 			tag = tag.replace(/\^([^^]*)\^/g, "<sup>$1</sup>");
 			tag = tag.replace(/~([^~]*)~/g, "<sub>$1</sub>");
-			tag = tag.replace(/\\}/g, "&rbrace;").replace(/\{{2}(.*?)\}{2}/g, `<code style='font-family: ${MONOSPACE_FONT_FAMILY}'>$1</code>`);
+			//Modidfied to add pre tag
+			tag = tag.replace(/\\}/g, "&rbrace;").replace(/\{{2}(.*?)\}{2}/g, `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>$1</code></pre>`);
 			tag = tag.replace(/\?{2}(.*)\?{2}/g, "<cite>$1</cite>");
 			tag = tag.replace(/\{color:([^}]+)\}/g, "<span style='color:$1;'>").replace(/\{color\}/g, '</span>');
 
@@ -164,19 +168,22 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		});
 
 		// code block tag
-		const code_block_re = /\{code(.*)}/;
+		// const code_block_re = /\{code(.*)}/
+		const code_block_re = /\{code([^}]*)\}/;
 		const code_block_match = tag.match(code_block_re);
 		if (code_block_match) {
 			if (! codeBlockTagFlag) {
 				let panelStyle = "";
 				let titleStyle = "";
-				tag = tag.replace(code_block_re, function (m0, m1) {
-					let res = '<div class="code-panel code-body" $panelStyle>'
+				tag = tag.replace(code_block_re, function (m0, m1, m2) {
+					let res = '<pre><code $panelStyle>'
 					const splits = m1.split(/[|:]/);
 					splits.forEach( (el:string) => {
 						const elems = el.split('=');
 						if (elems[0] === "title"){
-							res = `<div class="code-panel code-title" $titleStyle>${elems[1]}</div>${res}`;
+							res = `<div class="code-panel"><span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
+						} else {
+							res = `<div class="code-panel">${res}`;
 						}
                         // Disabled for now.
 						// if (elems[0] === "theme"){
@@ -199,15 +206,62 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 				});
 				codeBlockTagFlag = true;
 			} else {
-				tag = '</div>';
+				// This seems inververted. I'm not sure if it needs corrected.
+				// tag = '</pre></code>';
+				tag = '</code></pre>';
 				codeBlockTagFlag = false;
 			}
 		}
 
+		// Attempt #2
+		// const code_re = /\{code(.*)}/;
+		// const code_match = tag.match(code_re);
+		// if (code_match) {
+		// 	if (! codeTagFlag) {
+		// 		let panelStyle = "";
+		// 		let titleStyle = "";
+		// 		tag = tag.replace(code_re, function (m0, m1, m2) {
+		// 			let res = '<code class="code-body" $panelStyle>'
+		// 			const splits = m1.split(/[|:]/);
+		// 			splits.forEach( (el:string) => {
+		// 				const elems = el.split('=');
+		// 				if (elems[0] === "title"){
+		// 					// res = `<pre><div class="code-panel code-title" $titleStyle>${elems[1]}</div>${res}`;
+		// 					res = `<pre><span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
+		// 				} else {
+		// 					res = `<pre>${res}`;
+		// 				}
+        //                 // Disabled for now.
+		// 				// if (elems[0] === "theme"){
+		// 				// 	if (panelStyle.length === 0) {
+		// 				// 		panelStyle = `style='background-color: ${elems[1]};`;
+		// 				// 	} else {
+		// 				// 		panelStyle += ` background-color: ${elems[1]};`;
+		// 				// 	}
+		// 				// }
+		// 			});
+		// 			if (titleStyle.length > 0) {
+		// 				titleStyle += `'`;
+		// 			}
+		// 			if (panelStyle.length > 0) {
+		// 				panelStyle += `'`;
+		// 			}
+		// 			res = res.replace('$panelStyle', panelStyle);
+		// 			res = res.replace('$titleStyle', titleStyle);
+		// 			return res;
+		// 		});
+		// 		codeTagFlag = true;
+		// 	} else {
+		// 		tag = '</pre></code>';
+		// 		codeTagFlag = false;
+		// 	}
+		// }
+
 
 		// old code tag
-		// const code_re = /\{(noformat|code)[^}]*\}/;
+		// const code_re = /\{code[^}]*\}/;
 		// const code_match = tag.match(code_re);
+		// console.log(code_match);
 		// if (code_match) {
 		// 	if (! codeTagFlag) {
 		// 		tag = `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`;

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -173,30 +173,48 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		const code_panel_close_match = tag.match(code_panel_close_re);
 		if (code_panel_open_match) {
 			if (! codeBlockTagFlag) {
-				let panelStyle = "";
-				let titleStyle = "";
+				let codeBlockStyle = "";
+				// let titleStyle = "";
 				tag = tag.replace(code_panel_open_re, function (m0, m1) {
-					let res = '<pre><code $panelStyle>'
+					let res = '<pre><code $codeBlockStyle>'
 					const splits = m1.split(/[|:]/);
 					splits.forEach( (el:string) => {
 						const elems = el.split('=');
 						if (elems[0] === "title"){
-							res = `<span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
+							res = `<span class="code-title">${elems[1]}</span>${res}`;
+							// Title style is unecessary for now.
+							// res = `<span class="code-title" $titleStyle>${elems[1]}</span>${res}`;
 						}
-						// Disabled for now. I'd like to add the standard confluence code block themes later.
-						// if (elems[0] === "theme"){
+						// Basic theme matching.
+						if (elems[0] === "theme"){
 							// Add some sort of switch statement in here.
-						// }
+							switch (elems[1].toLowerCase()) {
+								case "django":
+									codeBlockStyle = `style='color:#f8f8f8;background-color:#0a2b1d;'`;
+									break;
+								case "emacs":
+									codeBlockStyle = `style='color:#d3d3d3;background-color:black;'`;
+									break;
+								case "fadetogrey":
+									codeBlockStyle = `style='color:white;background-color:#121212;'`;
+									break;
+								case "midnight":
+									codeBlockStyle = `style='color:#d1edff;background-color:#0f192a;'`;
+									break;
+								case "rdark":
+									codeBlockStyle = `style='color:#b9bdb6;background-color:#1b2426;'`;
+									break;
+								case "eclipse":
+									codeBlockStyle = `style='color:white;background-color:black;'`;
+									break;
+								case "confluence":
+									codeBlockStyle = `style='color:white;background-color:black;'`;
+								}
+						}
 					});
 					res = `<div class="code-panel">${res}`;
-					if (titleStyle.length > 0) {
-						titleStyle += `'`;
-					}
-					if (panelStyle.length > 0) {
-						panelStyle += `'`;
-					}
-					res = res.replace('$panelStyle', panelStyle);
-					res = res.replace('$titleStyle', titleStyle);
+					res = res.replace('$codeBlockStyle', codeBlockStyle);
+					// res = res.replace('$titleStyle', titleStyle);
 					return res;
 				});
 				codeBlockTagFlag = true;

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -168,11 +168,11 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 
 
 
-		// code block tag
-		// const code_re = /\{code[^}]*\}/;
-		const code_re = /\{code(.*)\}/;
-		const code_match = tag.match(code_re);
-		if (code_match) {
+		// code panel tag
+		// const code_panel_re = /\{code[^}]*\}/;
+		const code_panel_re = /\{code(.*)\}/;
+		const code_panel_match = tag.match(code_panel_re);
+		if (code_panel_match) {
 			if (! codeBlockTagFlag) {
 				let panelStyle = "";
 				let titleStyle = "";

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -185,11 +185,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 					}
 					// Disabled for now. I'd like to add the standard confluence code block themes later.
 					// if (elems[0] === "theme"){
-					// 	if (panelStyle.length === 0) {
-					// 		panelStyle = `style='background-color: ${elems[1]};`;
-					// 	} else {
-					// 		panelStyle += ` background-color: ${elems[1]};`;
-					// 	}
+						// Add some sort of switch statement in here.
 					// }
 				});
 				res = `<div class="code-panel">${res}`;
@@ -201,11 +197,10 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 				}
 				res = res.replace('$panelStyle', panelStyle);
 				tag = res.replace('$titleStyle', titleStyle);
-				// console.log('tag=' + tag);
 				codeBlockTagFlag = true;
 			} else {
-				// This seems inververted. I'm not sure if it needs corrected.
-				// tag = '</pre></code>';
+				// This seems inververted and has been corrected.
+				// tag = '</pre></code></div>';
 				tag = '</code></pre></div>';
 				codeBlockTagFlag = false;
 			}
@@ -217,7 +212,6 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		// if (code_match) {
 		// 	if (! codeTagFlag) {
 		// 		tag = `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>`;
-		// 		console.log('tag=' + tag);
 		// 		codeTagFlag = true;
 		// 	} else {
 		// 		tag = '</pre></code>';

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -355,10 +355,13 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 				listFlag = false;
 			}
 
+			if (! codeTagFlag) {
 			// hr and dash lines
 			tag = tag.replace(/-{4,}/gi, '<hr />');
 			tag = tag.replace(/-{3}/gi, '&mdash;');
 			tag = tag.replace(/-{2}/gi, '&ndash;');
+			}
+
 			// strong
 			tag = tag.replace(/\*([^*]*)\*/g, "<strong>$1</strong>");
 			// line-through

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -157,13 +157,13 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		}
 
 		// code
-		// one line code and noformat tag
+		// oneline code and noformat tag
 		tag = tag.replace(/\{(noformat|code)[^}]*\}(.*)\{(noformat|code)\}/, function (m0, m1, m2) {
 			return `<pre><code style='font-family: ${MONOSPACE_FONT_FAMILY}'>${m2.replace(/</gi, '&lt;')}</code></pre>`;
 		});
 
 
-		// code and noformat block tag
+		// code and noformat tag
 		const code_re = /\{(noformat|code)([^}]*)\}/;
 		const code_match = tag.match(code_re);
 		if (code_match) {
@@ -226,7 +226,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		}
 
 		const panel_re = /\{panel(.*)}/;
-		if ((! codeTagFlag) && tag.match(panel_re)) {
+		if (! codeTagFlag && tag.match(panel_re)) {
 			if (! panelTagFlag ) {
 				let panelStyle = "";
 				let titleStyle = "";

--- a/src/markupParser.ts
+++ b/src/markupParser.ts
@@ -52,7 +52,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 	let result = '';
 	let listTag = '';
 	let listStyle = '';
-	let codeBlockTagFlag = false;
+	let codeTagFlag = false;
 	let panelTagFlag = false;
 	let tableFlag = false;
 	let listFlag = false;
@@ -65,12 +65,12 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		if ((tag.length === 0 )
 			&& (! listFlag)
 			&& (! tableFlag)
-			&& (! codeBlockTagFlag)
+			&& (! codeTagFlag)
 			) {
 			continue;
 		}
 
-		if (! codeBlockTagFlag) {
+		if (! codeTagFlag) {
 			tag = tag.replace(/h(\d+)\.\s([^\n]+)/g, "<h$1>$2</h$1>");
 
 			// tag = tag.replace(/_([^_]*)_/g, "<em>$1</em>");
@@ -167,7 +167,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 		const code_re = /\{(noformat|code)([^}]*)\}/;
 		const code_match = tag.match(code_re);
 		if (code_match) {
-			if (! codeBlockTagFlag) {
+			if (! codeTagFlag) {
 				let codeBlockStyle = "";
 				// Title style is unecessary for now. It can't be easily customized in Confluence.
 				// let titleStyle = "";
@@ -211,22 +211,22 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 					// res = res.replace('$titleStyle', titleStyle);
 					return res;
 				});
-				codeBlockTagFlag = true;
+				codeTagFlag = true;
 			} else {
 				tag = '</pre></code></div>';
 				//This pays attention to the list flag and adds the closing </li> tag if needed.
 				if (listFlag) {
 					tag = `${tag}</li>`;
 				}
-				codeBlockTagFlag = false;
+				codeTagFlag = false;
 			}
 		}
-		if (codeBlockTagFlag && ! code_match) {
+		if (codeTagFlag && ! code_match) {
 			tag = tag.replace(/</gi, '&lt;') + '<br />';
 		}
 
 		const panel_re = /\{panel(.*)}/;
-		if ((! codeBlockTagFlag) && tag.match(panel_re)) {
+		if ((! codeTagFlag) && tag.match(panel_re)) {
 			if (! panelTagFlag ) {
 				let panelStyle = "";
 				let titleStyle = "";
@@ -309,7 +309,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 			}
 		}
 
-		// if (! innerCodeTagFlag) {
+		// if (! codeTagFlag) {
 			// lists
 			const li_re = /^([-*#]+)\s(.*)/;
 			const li_match = tag.match(li_re);
@@ -340,7 +340,7 @@ export function parseMarkup(sourceUri: vscode.Uri, sourceText: string) {
 					listArr = listArr.slice(0, li_match[1].length);
 				}
 				// This prevents the closing </li> tag from being added too prematurely.
-				if (codeBlockTagFlag || panelTagFlag) {
+				if (codeTagFlag || panelTagFlag) {
 					tag += "<li>" + li_match[2];
 				} else {
 					tag += "<li>" + li_match[2] + "</li>";

--- a/src/test/suite/fixtures/expected/issues.html
+++ b/src/test/suite/fixtures/expected/issues.html
@@ -6,16 +6,18 @@
 <p>
 	<a href='https://github.com/denco/vscode-confluence-markup/issues/3'>#3</a>: Noformat macro</p>
 <p>
-	<pre>
-		<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
-		<p>$ date -R -v+1d
-			<br />
-		</p>
-		<p>Sat, 10 Feb 2018 10:37:39 +0100
-			<br />
-		</p>
-		<p></pre>
-	</code>
+	<div class="code-block">
+		<pre>
+			<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
+			<p>$ date -R -v+1d
+				<br />
+			</p>
+			<p>Sat, 10 Feb 2018 10:37:39 +0100
+				<br />
+			</p>
+			<p></pre>
+		</code>
+	</div>
 </p>
 <p>
 	<a href='https://github.com/denco/vscode-confluence-markup/issues/5'>#5</a>: Table without heading</p>

--- a/src/test/suite/fixtures/expected/test.html
+++ b/src/test/suite/fixtures/expected/test.html
@@ -258,31 +258,37 @@
 	</h2>
 </p>
 <p>
-	<pre>
-		<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
-		<p>&lt;test>
-			<br />
-		</p>
-		<p>&lt;test1 />
-			<br />
-		</p>
-		<p>&lt;/test>
-			<br />
-		</p>
-		<p></pre>
-	</code>
+	<div class="code-block">
+		<span class="code-title">test</span>
+		<pre>
+			<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
+			<p>&lt;test>
+				<br />
+			</p>
+			<p>&lt;test1 />
+				<br />
+			</p>
+			<p>&lt;/test>
+				<br />
+			</p>
+			<p></pre>
+		</code>
+	</div>
 </p>
 <p>
-	<pre>
-		<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
-		<p>bash
-			<br />
-		</p>
-		<p>echo very long command line with a lot of sings to check word wrap and how it looks like && echo much more elements to print
-			<br />
-		</p>
-		<p></pre>
-	</code>
+	<div class="code-block">
+		<span class="code-title">title</span>
+		<pre>
+			<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
+			<p>bash
+				<br />
+			</p>
+			<p>echo very long command line with a lot of sings to check word wrap and how it looks like && echo much more elements to print
+				<br />
+			</p>
+			<p></pre>
+		</code>
+	</div>
 </p>
 <p>
 	<pre>

--- a/src/test/suite/fixtures/expected/test.html
+++ b/src/test/suite/fixtures/expected/test.html
@@ -303,16 +303,18 @@
 	</h2>
 </p>
 <p>
-	<pre>
-		<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
-		<p>&lt;xml>
-			<br />
-		</p>
-		<p>&lt;/xml>
-			<br />
-		</p>
-		<p></pre>
-	</code>
+	<div class="code-block">
+		<pre>
+			<code style='font-family: Menlo, Monaco, Consolas, monospace'></p>
+			<p>&lt;xml>
+				<br />
+			</p>
+			<p>&lt;/xml>
+				<br />
+			</p>
+			<p></pre>
+		</code>
+	</div>
 </p>
 <p>
 	<pre>


### PR DESCRIPTION
- add code panel feature that shows titles similar to the panels
- modified parsing to allow for panels, code, and code blocks to be in ordered or unordered lists

Screenshot:
<img width="659" alt="Screenshot 2023-10-05 at 11 07 38 PM" src="https://github.com/denco/vscode-confluence-markup/assets/5820031/26872199-6729-4fc4-9799-e8296d93f5e6">

Please let me know if I need to make any changes. 
